### PR TITLE
Use plain Jackson to get effectively the same deserialization results.

### DIFF
--- a/src/main/java/com/rethinkdb/RethinkDB.java
+++ b/src/main/java/com/rethinkdb/RethinkDB.java
@@ -1,5 +1,6 @@
 package com.rethinkdb;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rethinkdb.gen.model.TopLevel;
 import com.rethinkdb.net.Connection;
@@ -10,7 +11,7 @@ public class RethinkDB extends TopLevel {
      * The Singleton to use to begin interacting with RethinkDB Driver
      */
     public static final RethinkDB r = new RethinkDB();
-    private static ObjectMapper mapper = new ObjectMapper();
+    private static ObjectMapper mapper = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     public Connection.Builder connection() {
         return Connection.build();
     }

--- a/src/main/java/com/rethinkdb/net/Util.java
+++ b/src/main/java/com/rethinkdb/net/Util.java
@@ -45,9 +45,19 @@ public class Util {
     }
 
     public static <T, P> T convertToPojo(Object value, Optional<Class<P>> pojoClass) {
-        return !pojoClass.isPresent() || !(value instanceof Map)
-                ? (T) value
-                : (T) RethinkDB.getObjectMapper().convertValue(value, pojoClass.get());
+        if (pojoClass.isPresent()) {
+            if (pojoClass.get().isEnum()) {
+                Enum<?>[] enumConstants = ((Class<Enum<?>>) pojoClass.get()).getEnumConstants();
+                for (Enum<?> enumConst : enumConstants) {
+                    if (enumConst.name().equals(value)) {
+                        return (T) enumConst;
+                    }
+                }
+            } else if (value instanceof Map) {
+                return (T) RethinkDB.getObjectMapper().convertValue(value, pojoClass.get());
+            }
+        }
+        return (T) value;
     }
 
     public static byte[] toUTF8(String s) {

--- a/src/main/java/com/rethinkdb/net/Util.java
+++ b/src/main/java/com/rethinkdb/net/Util.java
@@ -47,7 +47,7 @@ public class Util {
     public static <T, P> T convertToPojo(Object value, Optional<Class<P>> pojoClass) {
         return !pojoClass.isPresent() || !(value instanceof Map)
                 ? (T) value
-                : (T) toPojo(pojoClass.get(), (Map<String, Object>) value);
+                : (T) RethinkDB.getObjectMapper().convertValue(value, pojoClass.get());
     }
 
     public static byte[] toUTF8(String s) {
@@ -56,43 +56,6 @@ public class Util {
 
     public static String fromUTF8(byte[] ba) {
         return new String(ba, StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Converts a String-to-Object map to a POJO using bean introspection.<br>
-     * The POJO's class must be public and satisfy one of the following conditions:<br>
-     * 1. Should have a public parameterless constructor and public setters for all properties
-     * in the map. Properties with no corresponding entries in the map would have default values<br>
-     * 2. Should have a public constructor with parameters matching the contents of the map
-     * either by names and value types. Names of parameters are only available since Java 8
-     * and only in case <code>javac</code> is run with <code>-parameters</code> argument.<br>
-     * If the POJO's class doesn't satisfy the conditions, a ReqlDriverError is thrown.
-     * @param <T> POJO's type
-     * @param pojoClass POJO's class to be instantiated
-     * @param map Map to be converted
-     * @return Instantiated POJO
-     */
-    @SuppressWarnings("unchecked")
-    private static <T> T toPojo(Class<T> pojoClass, Map<String, Object> map) {
-        // Jackson will throw an error if the POJO is not annotated with an ignore
-        // annotation and the server gives a value that is not a field within the POJO To
-        // prevent this, we get a list of all the field names from the class, and iterate
-        // through the map. If the map contains a key that the does not correlate to a
-        // field name, then that entry from the map is removed and we log an error.
-        List<String> nameFields = new ArrayList<>();
-        Arrays.asList(pojoClass.getDeclaredFields()).forEach(field -> nameFields.add(field.getName()));
-        List<String> toRemove = new ArrayList<>();
-
-        map.keySet().forEach(s -> {
-            if (!nameFields.contains(s))
-            {
-                log.error("Got JSON field [" + s + "] from server. POJO does not contain field, removing from map!");
-                toRemove.add(s);
-            }
-        });
-        toRemove.forEach(map::remove);
-
-        return RethinkDB.getObjectMapper().convertValue(map, pojoClass);
     }
 }
 


### PR DESCRIPTION
Jackson has a built-in feature which makes this irrelevant. The plain ObjectMapper can be used if an DeserializationFeature is disabled.