### PR TITLE
Initial ci config without deployment and coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,11 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+# Exclude the signArchives tasks, since the deploy configuration will be
+# added when vault is set up. The secrets should come from there.
+# TODO: @gabor-boros Integrate vault
+script:
+  - ./gradlew assemble --exclude-task signArchives
+
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 # Exclude the signArchives tasks, since the deploy configuration will be
 # added when vault is set up. The secrets should come from there.
 # TODO: @gabor-boros Integrate vault
-script:
+install:
   - ./gradlew assemble --exclude-task signArchives
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: java
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: xenial
+language: java
+
+jdk:
+  - oraclejdk8
+  - openjdk8
+
+services:
+  - docker
+
+before_install:
+  - docker pull rethinkdb:latest
+  - docker run -d -p 28015:28015 -p 29015:29015 -p 8080:8080 rethinkdb:latest
+  - docker ps -a
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+notifications:
+    email: false


### PR DESCRIPTION
Adding initial CI/CD config without deployment and coverage. Later on, the following will be added:

* Codacy integration
* Test coverage report
* Deployment to Sonatype/BinTray on GitHub Tag creation