### PR TITLE
Gradle optional signing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,17 @@ signing {
     sign(configurations.archives.get())
 }
 
-
+gradle.taskGraph.whenReady {
+    val hasUploadArchives = hasTask(":uploadArchives")
+    val hasDoSigning = hasTask(":doSigning")
+    signing.isRequired = hasUploadArchives || hasDoSigning
+}
 
 fun findProperty(s: String) = project.findProperty(s) as String?
 tasks {
+    val doSigning by creating {
+        dependsOn("signArchives")
+    }
     withType<JavaCompile> {
         options.encoding = "UTF-8"
     }


### PR DESCRIPTION
Modifies Gradle build to sign files if calling `doSigning` or `uploadArchives` task.