### PR TITLE
Add support for confidential properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 .#*
 *.iml
 .idea/
+confidential.properties
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # RethinkDB Java Driver
 
-[ ![Download](https://api.bintray.com/packages/rethinkdb/maven/rethinkdb-driver/images/download.svg) ](https://bintray.com/rethinkdb/maven/rethinkdb-driver/_latestVersion)
+[![Maven Central](https://img.shields.io/maven-central/v/com.rethinkdb/rethinkdb-driver)](https://search.maven.org/artifact/com.rethinkdb/rethinkdb-driver)
+[![Bintray](https://img.shields.io/bintray/v/rethinkdb/maven/rethinkdb-driver)](https://bintray.com/rethinkdb/maven/rethinkdb-driver/_latestVersion)
+[![Travis-CI.org](https://img.shields.io/travis/rethinkdb/rethinkdb-java)](https://travis-ci.org/rethinkdb/rethinkdb-java)
+[![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Frethinkdb%2Frethinkdb-java)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Frethinkdb%2Frethinkdb-java)
 
 This is the official [RethinkDB](https://rethinkdb.com/) client driver for Java and other JVM languages.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ These are also checked into git, so you don't need to run the conversion script 
 
 ## Deploying a release or snapshot
 
-To deploy you'll need to create a file called `gradle.properties` at `~/.gradle` (`%USERPROFILE%\.gradle` on Windows) with the following:
+To deploy, you'll need to create a file called `confidential.properties` in the same directory as `build.gradle.kts` 
+(Alternatively, you can do the same`gradle.properties` at `~/.gradle` (`%USERPROFILE%\.gradle` on Windows) with the following:
 
 ```
 signing.keyId=<KEY_ID>
@@ -106,7 +107,8 @@ ossrhPassword=<SONATYPE_PASSWORD>
 ```
 
 You should note that there's a `gradle.properties` in this repository, but you shouldn't add the above into it,
-otherwise your credentials can be checked back into git. Create the file in the `.gradle` folder to prevent accidents.
+otherwise your credentials can be checked back into git. Create the `confidential.properties` file, which is added into
+`.gitignore`, or create the file in the `.gradle` folder, in order to prevent accidents.
 
 You'll need to add your gpg signing key id and keyring file. Usually, the keyring file is located at`~/.gnupg/secring.gpg`,
 but Gradle won't expand home-dirs in the config file so you have to put the absolute path to your keyring file.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.File
+
 plugins {
     java
     maven
@@ -6,8 +9,6 @@ plugins {
 
 version = "2.4.0"
 group = "com.rethinkdb"
-
-val isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
@@ -23,6 +24,12 @@ dependencies {
     compile("org.slf4j:slf4j-api:1.7.12")
     compile("com.googlecode.json-simple:json-simple:1.1.1")
     compile("com.fasterxml.jackson.core:jackson-databind:2.0.1")
+}
+
+file("confidential.properties").takeIf(File::exists)?.let {
+    val properties = Properties()
+    it.inputStream().use(properties::load)
+    allprojects { properties.forEach { name, value -> extra.set(name.toString(), value) } }
 }
 
 signing {


### PR DESCRIPTION
Added a 3 line snippet that should parse a `confidential.properties` file, if it exists, and add it's properties to the project. That file was added to `.gitignore`, so we can safely add credentials into it.

`README.md` instructions was modified to explain how it works.