### PR TITLE
Types utility class

### DIFF
--- a/src/main/java/com/rethinkdb/ast/ReqlAst.java
+++ b/src/main/java/com/rethinkdb/ast/ReqlAst.java
@@ -9,8 +9,8 @@ import com.rethinkdb.model.Arguments;
 import com.rethinkdb.model.OptArgs;
 import com.rethinkdb.net.Connection;
 import com.rethinkdb.net.Result;
+import com.rethinkdb.utils.Types;
 
-import java.lang.reflect.Type;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
@@ -95,7 +95,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> Result<T> run(Connection conn, Class<T> typeRef) {
-        return conn.run(this, new OptArgs(), null, new ClassReference<>(typeRef));
+        return conn.run(this, new OptArgs(), null, Types.of(typeRef));
     }
 
     /**
@@ -135,7 +135,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> Result<T> run(Connection conn, OptArgs runOpts, Class<T> typeRef) {
-        return conn.run(this, runOpts, null, new ClassReference<>(typeRef));
+        return conn.run(this, runOpts, null, Types.of(typeRef));
     }
 
     /**
@@ -163,7 +163,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> Result<T> run(Connection conn, Result.FetchMode fetchMode, Class<T> typeRef) {
-        return conn.run(this, new OptArgs(), fetchMode, new ClassReference<>(typeRef));
+        return conn.run(this, new OptArgs(), fetchMode, Types.of(typeRef));
     }
 
     /**
@@ -192,7 +192,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> Result<T> run(Connection conn, OptArgs runOpts, Result.FetchMode fetchMode, Class<T> typeRef) {
-        return conn.run(this, runOpts, fetchMode, new ClassReference<>(typeRef));
+        return conn.run(this, runOpts, fetchMode, Types.of(typeRef));
     }
 
     /**
@@ -254,7 +254,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> CompletableFuture<Result<T>> runAsync(Connection conn, Class<T> typeRef) {
-        return conn.runAsync(this, new OptArgs(), null, new ClassReference<>(typeRef));
+        return conn.runAsync(this, new OptArgs(), null, Types.of(typeRef));
     }
 
     /**
@@ -294,7 +294,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> CompletableFuture<Result<T>> runAsync(Connection conn, OptArgs runOpts, Class<T> typeRef) {
-        return conn.runAsync(this, runOpts, null, new ClassReference<>(typeRef));
+        return conn.runAsync(this, runOpts, null, Types.of(typeRef));
     }
 
     /**
@@ -322,7 +322,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> CompletableFuture<Result<T>> runAsync(Connection conn, Result.FetchMode fetchMode, Class<T> typeRef) {
-        return conn.runAsync(this, new OptArgs(), fetchMode, new ClassReference<>(typeRef));
+        return conn.runAsync(this, new OptArgs(), fetchMode, Types.of(typeRef));
     }
 
     /**
@@ -351,7 +351,7 @@ public class ReqlAst {
      * @return The result of this query
      */
     public <T> CompletableFuture<Result<T>> runAsync(Connection conn, OptArgs runOpts, Result.FetchMode fetchMode, Class<T> typeRef) {
-        return conn.runAsync(this, runOpts, fetchMode, new ClassReference<>(typeRef));
+        return conn.runAsync(this, runOpts, fetchMode, Types.of(typeRef));
     }
 
     /**
@@ -436,24 +436,6 @@ public class ReqlAst {
                     indent + (tail ? "    " : "│   ") + "    ",
                     !optIterator.hasNext());
             }
-        }
-    }
-
-    /**
-     * A TypeReference that accepts an class instead of compiler type information.
-     *
-     * @param <T> the type referred to.
-     */
-    private static class ClassReference<T> extends TypeReference<T> {
-        private Class<T> c;
-
-        ClassReference(Class<T> c) {
-            this.c = c;
-        }
-
-        @Override
-        public Type getType() {
-            return c;
         }
     }
 }

--- a/src/main/java/com/rethinkdb/net/Util.java
+++ b/src/main/java/com/rethinkdb/net/Util.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.rethinkdb.RethinkDB;
 import com.rethinkdb.gen.exc.ReqlDriverError;
+import com.rethinkdb.utils.Types;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -11,7 +12,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 
 public class Util {
-    private static final TypeReference<Map<String, Object>> mapTypeRef = new TypeReference<Map<String, Object>>() {};
+    private static final TypeReference<Map<String, Object>> mapTypeRef = Types.mapOf(String.class, Object.class);
 
     private Util() {}
 

--- a/src/main/java/com/rethinkdb/utils/Types.java
+++ b/src/main/java/com/rethinkdb/utils/Types.java
@@ -1,0 +1,131 @@
+package com.rethinkdb.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.lang.reflect.MalformedParameterizedTypeException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * An utility class that can create simple generic type references without having to grab information from the compiler.
+ */
+public class Types {
+    private Types() {
+    }
+
+    public static <T> TypeReference<T> of(Class<T> type) {
+        return new BuiltTypeRef<>(Objects.requireNonNull(type, "type"));
+    }
+
+    public static <T> TypeReference<List<T>> listOf(Class<T> type) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(List.class, Objects.requireNonNull(type, "type"))
+        );
+    }
+
+    public static <T> TypeReference<List<T>> listOf(TypeReference<T> type) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(List.class, Objects.requireNonNull(type, "type").getType())
+        );
+    }
+
+    public static <T> TypeReference<Set<T>> setOf(Class<T> type) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(Set.class, Objects.requireNonNull(type, "type"))
+        );
+    }
+
+    public static <T> TypeReference<Set<T>> setOf(TypeReference<T> type) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(Set.class, Objects.requireNonNull(type, "type").getType())
+        );
+    }
+
+    public static <K, V> TypeReference<Map<K, V>> mapOf(Class<K> keyType, Class<V> valueType) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(Map.class, Objects.requireNonNull(keyType, "keyType"), Objects.requireNonNull(valueType, "valueType"))
+        );
+    }
+
+    public static <K, V> TypeReference<Map<K, V>> mapOf(TypeReference<K> keyType, Class<V> valueType) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(Map.class, Objects.requireNonNull(keyType, "keyType").getType(), Objects.requireNonNull(valueType, "valueType"))
+        );
+    }
+
+    public static <K, V> TypeReference<Map<K, V>> mapOf(Class<K> keyType, TypeReference<V> valueType) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(Map.class, Objects.requireNonNull(keyType, "keyType"), Objects.requireNonNull(valueType, "valueType").getType())
+        );
+    }
+
+    public static <K, V> TypeReference<Map<K, V>> mapOf(TypeReference<K> keyType, TypeReference<V> valueType) {
+        return new BuiltTypeRef<>(
+            new BuiltParametrizedType(Map.class, Objects.requireNonNull(keyType, "keyType").getType(), Objects.requireNonNull(valueType, "valueType").getType())
+        );
+    }
+
+    private static class BuiltTypeRef<T> extends TypeReference<T> {
+        private final Type type;
+
+        private BuiltTypeRef(Type type) {
+            this.type = type;
+        }
+
+        @Override
+        public Type getType() {
+            return type;
+        }
+    }
+
+    private static class BuiltParametrizedType implements ParameterizedType {
+        private final Class<?> type;
+        private final Type[] params;
+
+        public BuiltParametrizedType(Class<?> type, Type... params) {
+            if (params.length != type.getTypeParameters().length) {
+                throw new MalformedParameterizedTypeException();
+            }
+            this.type = type;
+            this.params = params;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return params.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return type;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return type.getDeclaringClass();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ParameterizedType)) return false;
+            ParameterizedType that = (ParameterizedType) o;
+            return Objects.equals(type, that.getRawType()) &&
+                Objects.equals(type.getDeclaringClass(), that.getOwnerType()) &&
+                Arrays.equals(params, that.getActualTypeArguments());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(params) ^ Objects.hashCode(type) ^ Objects.hashCode(type.getDeclaringClass());
+        }
+
+        @Override
+        public String toString() {
+            return type.getName() + Arrays.stream(params).map(Type::getTypeName)
+                .collect(Collectors.joining(", ", "<", ">"));
+        }
+    }
+}


### PR DESCRIPTION
Creates a utility class `Types`, which aims to replace some TypeReference generic classes across the driver main and test code, as well as expose it to the driver users.

Examples:
```groovy
new TypeReference<Map<String, Object>>() {};
// turns into
Types.mapOf(String.class, Object.class);
```
```groovy
new TypeReference<List<String>>() {};
// turns into
Types.listOf(String.class);
```

Building generics types are faster than loading them from type information because that amounts to *one class load per type reference*, versus a few invoke calls and load constants.

_Yes, I reverse-engineered the type system and Jackson type system to make this._
