### PR TITLE
Refactored Converter class

### DIFF
--- a/src/main/java/com/rethinkdb/model/GroupedResult.java
+++ b/src/main/java/com/rethinkdb/model/GroupedResult.java
@@ -3,9 +3,12 @@ package com.rethinkdb.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-@Deprecated
 public class GroupedResult<G, V> {
     private final G group;
     private final List<V> values;
@@ -22,5 +25,9 @@ public class GroupedResult<G, V> {
 
     public List<V> getValues() {
         return values;
+    }
+
+    public static <G, V> Map<G, Set<V>> toMap(List<GroupedResult<G, V>> list) {
+        return list.stream().collect(Collectors.toMap(GroupedResult::getGroup, it -> new LinkedHashSet<>(it.getValues())));
     }
 }

--- a/src/main/java/com/rethinkdb/model/GroupedResult.java
+++ b/src/main/java/com/rethinkdb/model/GroupedResult.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@Deprecated
 public class GroupedResult<G, V> {
     private final G group;
     private final List<V> values;

--- a/src/main/java/com/rethinkdb/net/Converter.java
+++ b/src/main/java/com/rethinkdb/net/Converter.java
@@ -88,7 +88,7 @@ public class Converter {
                 if (fmt.rawBinary) {
                     return value;
                 }
-                return Base64.getDecoder().decode((String) value.get("data"));
+                return Base64.getMimeDecoder().decode((String) value.get("data"));
             }
             case GEOMETRY: {
                 // Nothing specific here

--- a/src/main/java/com/rethinkdb/net/Converter.java
+++ b/src/main/java/com/rethinkdb/net/Converter.java
@@ -88,7 +88,7 @@ public class Converter {
                 if (fmt.rawBinary) {
                     return value;
                 }
-                return Base64.getMimeDecoder().decode((String) value.get("data"));
+                return Base64.getDecoder().decode((String) value.get("data"));
             }
             case GEOMETRY: {
                 // Nothing specific here
@@ -101,6 +101,6 @@ public class Converter {
     public static Map<String, Object> toBinary(byte[] data) {
         return new MapObject<String, Object>()
             .with("$reql_type$", BINARY)
-            .with("data", Base64.getMimeEncoder().encodeToString(data));
+            .with("data", Base64.getEncoder().encodeToString(data));
     }
 }

--- a/src/main/java/com/rethinkdb/net/Converter.java
+++ b/src/main/java/com/rethinkdb/net/Converter.java
@@ -60,8 +60,6 @@ public class Converter {
         return obj;
     }
 
-    //convertPseudotypes
-
     private static Object handlePseudotypes(Map<?, ?> value, FormatOptions fmt) {
         switch ((String) value.get(PSEUDOTYPE_KEY)) {
             case TIME: {
@@ -80,7 +78,7 @@ public class Converter {
                     return value;
                 }
                 return ((List<?>) value.get("data")).stream()
-                    .map(it -> new ArrayList<>((List<?>) it))
+                    .map(it -> new ArrayList<>((Collection<?>) it))
                     .map(it -> new GroupedResult<>(it.remove(0), it))
                     .collect(Collectors.toList());
             }

--- a/src/main/java/com/rethinkdb/net/Converter.java
+++ b/src/main/java/com/rethinkdb/net/Converter.java
@@ -3,6 +3,7 @@ package com.rethinkdb.net;
 
 import com.rethinkdb.gen.ast.Datum;
 import com.rethinkdb.gen.exc.ReqlDriverError;
+import com.rethinkdb.model.GroupedResult;
 import com.rethinkdb.model.MapObject;
 import com.rethinkdb.model.OptArgs;
 
@@ -80,7 +81,8 @@ public class Converter {
                 }
                 return ((List<?>) value.get("data")).stream()
                     .map(it -> new ArrayList<>((List<?>) it))
-                    .collect(Collectors.toMap(it -> it.remove(0), UnaryOperator.identity()));
+                    .map(it -> new GroupedResult<>(it.remove(0), it))
+                    .collect(Collectors.toList());
             }
             case BINARY: {
                 if (fmt.rawBinary) {


### PR DESCRIPTION
Mostly one-to-one rewriting, ended up removing unchecked code in the process.

Changes:

- Added `GroupedResult#toMap`, that converts `List<GroupedResults<K,V>>` to `Map<K, List<V>>`
- Binary terms now convert using default Base64 encoder instead of the MIME variant.