### PR TITLE
Rewrite readCString to avoid possible handshake hanging

### DIFF
--- a/src/main/java/com/rethinkdb/net/Connection.java
+++ b/src/main/java/com/rethinkdb/net/Connection.java
@@ -182,11 +182,12 @@ public class Connection implements Closeable {
                                       @Nullable TypeReference<T> typeRef) {
         try {
             return runAsync(term, optArgs, fetchMode, typeRef).join();
-        } catch (CompletionException e) {
-            if (e.getCause() instanceof ReqlError) {
-                throw ((ReqlError) e.getCause());
+        } catch (CompletionException ce) {
+            Throwable t = ce.getCause();
+            if (t instanceof ReqlError) {
+                throw ((ReqlError) t);
             }
-            throw e;
+            throw new ReqlDriverError(t);
         }
     }
 
@@ -212,12 +213,12 @@ public class Connection implements Closeable {
     public @NotNull Server server() {
         try {
             return serverAsync().join();
-        } catch (
-            CompletionException e) {
-            if (e.getCause() instanceof ReqlError) {
-                throw ((ReqlError) e.getCause());
+        } catch (CompletionException ce) {
+            Throwable t = ce.getCause();
+            if (t instanceof ReqlError) {
+                throw ((ReqlError) t);
             }
-            throw e;
+            throw new ReqlDriverError(t);
         }
     }
 
@@ -236,11 +237,12 @@ public class Connection implements Closeable {
     public void noreplyWait() {
         try {
             noreplyWaitAsync().join();
-        } catch (CompletionException e) {
-            if (e.getCause() instanceof ReqlError) {
-                throw ((ReqlError) e.getCause());
+        } catch (CompletionException ce) {
+            Throwable t = ce.getCause();
+            if (t instanceof ReqlError) {
+                throw ((ReqlError) t);
             }
-            throw e;
+            throw new ReqlDriverError(t);
         }
     }
 


### PR DESCRIPTION
Default `readCString` implementation can hang even with timeout due to the blocking `InputStream#read` before any timeout check. The method was rewritten to fix this.

Method was rewritten based on [this StackOverflow answer](https://stackoverflow.com/a/16313762).