### PR TITLE
Upgrade Jackson to 2.13.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testRuntime("ch.qos.logback:logback-classic:1.2.3")
     compile("org.slf4j:slf4j-api:1.7.30")
     compile("org.jetbrains:annotations:19.0.0")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.10.2")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.13.2.2")
 }
 
 file("confidential.properties").takeIf(File::exists)?.let {


### PR DESCRIPTION
**Reason for the change**

Jackson implemented native support for record classes, making serialization trivial for data POJOs.

In addition, upgrading fixes vulnerabilities:
[CVE-2020-25649](https://advisory.checkmarx.net/advisory/vulnerability/CVE-2020-25649/) 7.5 Improper Restriction of XML External Entity Reference vulnerability pending CVSS allocation
[CVE-2021-20190](https://advisory.checkmarx.net/advisory/vulnerability/CVE-2021-20190/) 8.1 Deserialization of Untrusted Data vulnerability pending CVSS allocation
[CVE-2020-10650](https://advisory.checkmarx.net/advisory/vulnerability/CVE-2020-10650/) 8.1 Deserialization of Untrusted Data vulnerability pending CVSS allocation
[Cxced0c06c-935c](https://advisory.checkmarx.net/advisory/vulnerability/Cxced0c06c-935c/) 5.9 Uncontrolled Resource Consumption vulnerability pending CVSS allocation
[CVE-2020-36518](https://advisory.checkmarx.net/advisory/vulnerability/CVE-2020-36518/) 7.5 Out-of-bounds Write vulnerability pending CVSS allocation

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)